### PR TITLE
git-merge-pr: Strip ^M from github PR messages

### DIFF
--- a/git-merge-pr
+++ b/git-merge-pr
@@ -160,6 +160,7 @@ EOF
 mergepr::_pr_message() {
   echo
   hub pr list -h "${merge_from_branch}" -f '%b' \
+  | tr -d \\015 \
   | awk "${markdown_for_commit_awk}"
 }
 


### PR DESCRIPTION
The merge commit is initially populated with the GitHub PR message body
(amongst other things), however, sometimes it has CRs (^M) at the end of
some lines. We don't want these in the merge commit message, so strip
them out.

Sorry Windows users.