### PR TITLE
git-pr-merge: Rename git-merge-pr to git-pr-merge

### DIFF
--- a/git-merge-pr
+++ b/git-merge-pr
@@ -1,0 +1,1 @@
+git-pr-merge

--- a/git-pr-merge
+++ b/git-pr-merge
@@ -10,7 +10,7 @@
 # branch, etc). This feature allows you to operate from the command line
 # instead of needing to use the GitHub web-ui to close a PR.
 #
-# Usage: git merge-pr [branch]
+# Usage: git pr-merge [branch]
 #
 # If [branch] is not supplied, the current branch will be merged into the
 # base branch for the PR. If [branch] is supplied, it is merged into the
@@ -25,26 +25,27 @@ main() {
   set -u
   set -o pipefail
 
-  mergepr::read_config
-  mergepr::setup "$@"
-  mergepr::prepare
-  mergepr::merge
-  mergepr::push
-  mergepr::clean
+  prmerge::read_config
+  prmerge::setup "$@"
+  prmerge::prepare
+  prmerge::merge
+  prmerge::push
+  prmerge::clean
 }
 
 # Read the config variables used by this script. Set them with:
-# git config merge-pr.delete-remote-branch true
-# git config --local merge-pr.title-prefix ''
-# git config --global merge-pr.sleep-time-before-delete 10
+# git config pr.merge.delete-remote-branch true
+# git config --local pr.merge.title-prefix ''
+# git config --global pr.merge.sleep-time-before-delete 10
 
-mergepr::read_config() {
-  mergepr::_get_config title_prefix title-prefix '✨ '
-  mergepr::_get_config delete_remote_branch delete-remote-branch true
-  mergepr::_get_config sleep_time_before_delete sleep-time-before-delete 15
+prmerge::read_config() {
+  prmerge::_migrate_config
+  prmerge::_get_config title_prefix title-prefix '✨ '
+  prmerge::_get_config delete_remote_branch delete-remote-branch true
+  prmerge::_get_config sleep_time_before_delete sleep-time-before-delete 15
 }
 
-mergepr::setup() {
+prmerge::setup() {
   if ! command -v hub >/dev/null; then
     printf 'You need to install hub (https://github.com/github/hub)\n' >&2
     return 1
@@ -70,7 +71,7 @@ mergepr::setup() {
   fi
 }
 
-mergepr::prepare() {
+prmerge::prepare() {
   echo merging "${merge_from_branch}" to "${merge_to_branch}"
 
   # Fetch from all remotes so we can check if local branch is up-to-date
@@ -90,11 +91,11 @@ mergepr::prepare() {
   fi
 }
 
-mergepr::merge() {
+prmerge::merge() {
   #open 'https://gist.github.com/rxaviers/7360908'
   #open 'https://gitmoji.carloscuesta.me'
 
-  if ! git merge --edit --no-ff -m "$(mergepr::_merge_message)" "${merge_from_branch}"; then
+  if ! git merge --edit --no-ff -m "$(prmerge::_merge_message)" "${merge_from_branch}"; then
     printf 'merge aborted\n' >&2
     git merge --abort
     if "${switch_needed}"; then
@@ -104,11 +105,11 @@ mergepr::merge() {
   fi
 }
 
-mergepr::push() {
+prmerge::push() {
   git push # push merge (closes PR)
 }
 
-mergepr::clean() {
+prmerge::clean() {
   git branch -d "${merge_from_branch}" # delete local branch
 
   if [[ "${delete_remote_branch}" == 'true' ]]; then
@@ -130,14 +131,19 @@ mergepr::clean() {
   fi
 }
 
-mergepr::_get_config() {
+prmerge::_migrate_config() {
+  git config --local --rename-section merge-pr pr.merge 2>/dev/null || true
+  git config --global --rename-section merge-pr pr.merge 2>/dev/null || true
+}
+
+prmerge::_get_config() {
   local var="$1" name="$2" default="$3"
   local val
-  val=$(git config --get --default "${default}" merge-pr."${name}")
+  val=$(git config --get --default "${default}" pr.merge."${name}")
   eval "${var}='${val}'"
 }
 
-mergepr::_merge_message() {
+prmerge::_merge_message() {
   # Create default merge log message by making a title prefix (from config),
   # title from the branch name, and the PR number, then adding a short log of
   # what is being merged and add a diff stat of the files changed by the merge.
@@ -145,7 +151,7 @@ mergepr::_merge_message() {
   title="${title//[-_]/ }" # convert _ and - to spaces
 cat <<EOF
 ${title_prefix}Merge ${title} (#${pr_num})
-$(mergepr::_pr_message)
+$(prmerge::_pr_message)
 
 $(git log --reverse --pretty=tformat:"* %s" "..${merge_from_branch}")
 
@@ -157,7 +163,7 @@ $(git diff --no-color --stat "...${merge_from_branch}")
 EOF
 }
 
-mergepr::_pr_message() {
+prmerge::_pr_message() {
   echo
   hub pr list -h "${merge_from_branch}" -f '%b' \
   | tr -d \\015 \


### PR DESCRIPTION
Rename git-merge-pr to git-pr-merge. This is in anticipation of adding
other "pr" subcommands, such as `git pr update`, etc and implementing
that as a `git-pr` binary.

Change function names in the shell script to reflect the new name.

Migrate the existing config section "merge-pr" to "pr.merge". This
migration will remain for a little while until all users update and
migrate all their repos.

Add a symlink from the old name to the new name so muscle memory can be
retrained slowly.