### PR TITLE
git-credential-subpath: Add credential helper

### DIFF
--- a/git-credential-subpath
+++ b/git-credential-subpath
@@ -1,0 +1,196 @@
+#!/bin/bash
+#
+# A credential helper to look up username based on path components.
+#
+# git credentials are able to be configured to provide a username for a host
+# name or a full URL path (if the `credential.useHttpPath` config is set). For
+# sites like like `github.com`, you may want to use a different username for
+# different sub-paths, as the first path component designates an organisation.
+# If you have a work and personal GitHub identity, you may want to select that
+# identity based on GitHub organisation. It is not possible to do that directly
+# with the configuration used by `gitcredentials(7)`.
+#
+# This script operates as a git credential helper to sit between git and the
+# real credential helper you want to use (called the chained helper in this
+# script). It takes the host and path and searches your git config for a
+# username by walking the path component by component.  If the full path
+# matches multiple config entries, the most specific one is selected. The
+# username from that configuration is passed to the chained helper so it can
+# provide the credentials for the correct username.
+#
+# This helper requires that the config setting `credential.useHttpPath` is
+# true, however it effectively disables that for the credential helper it
+# chains to, so that helper will not request or store a password per path
+# (which is rarely what you want - you want to be able to select the username
+# per path and the password per host/username pair).
+#
+# If you do need to have the chained helper see the path, you can set the
+# config option `credential.subpath.passPath` to true, but beware that it will
+# ask for your password for every repository even if it knows the host and
+# username for another repo.
+
+# Config command reference:
+# git config --global credential.helper subpath store
+# git config --global credential.useHttpPath true
+# git config --global credential.subpath.passPath true
+# git config --global credential.https://github.com/org.username octocat
+
+#-----------------------------------------------------------------------------
+usage() {
+  printf 'Usage: %s {<options>...} <chain> <get|store|erase>\n' "${0##*/}"
+  printf '  where <chain> is the credential helper to chain to.\n'
+  printf 'Available options:\n'
+  printf '  -d      print debugging input/output (warning will output password)\n'
+  printf '  -o arg  pass <arg> to the chained helper (multiple allowed)\n'
+}
+
+#-----------------------------------------------------------------------------
+main() {
+  set -euo pipefail
+  declare -A attrs
+  declare -a attr_order
+  declare -a chain_args
+  debug=false
+
+  parse_args "$@"
+
+  [[ "${cmd}" =~ (erase|get|store) ]] || { usage >&2; exit 1; }
+
+  read_attrs
+
+  # We do not alter the username for `set` operations as that provides a
+  # pair of (username, password) that belong toegether and that pair has
+  # been returned from a previous `get` operation.
+  if [[ "${cmd}" =~ (erase|get) ]]; then set_username_from_context; fi
+
+  config_has_pass_path || unset 'attrs[path]'
+
+  emit_attrs | run_next_helper "${cmd}"
+}
+
+#-----------------------------------------------------------------------------
+read_attrs() {
+  debug '%s: attributes read from git:\n' "${cmd}"
+  while read -r attrval; do
+    debug '  %s\n' "${attrval}"
+    local key="${attrval%%=*}"
+    local val="${attrval#*=}"
+    if [[ "${key}" == "${attrval}" ]]; then
+      # No = in attrval line. skip it
+      continue
+    fi
+    attrs["${key}"]="${val}"
+    attr_order+=("${key}")
+  done
+  debug '\n'
+}
+
+#-----------------------------------------------------------------------------
+emit_attrs() {
+  for key in "${attr_order[@]}"; do
+    if [[ -z "${attrs[${key}]+x}" ]]; then
+      continue
+    fi
+    printf '%s=%s\n' "${key}" "${attrs[${key}]}"
+  done
+}
+
+#-----------------------------------------------------------------------------
+run_next_helper() {
+  local cmd="$1"
+  debug_pipe 'running "git-credential-%s %s %s" with attributes: \n' \
+    "${chained_helper}" "${chain_args[*]}" "${cmd}" \
+    | "git-credential-${chained_helper}" "${chain_args[@]}" "${cmd}" \
+    | debug_pipe 'attributes returned from %s.%s\n' "${chained_helper}" "${cmd}"
+}
+
+#-----------------------------------------------------------------------------
+set_username_from_context() {
+  # Starting at the shortest path, iterating to the longest based on slash
+  # separated components of ${attrs[path]}, look up the git config for a
+  # credential username. The username of a longer path will override that of
+  # a shorter one.
+
+  declare -a path_components path_paths
+  local url
+
+  # Split path attribute on slashes, and prepend the protocol://host
+  IFS=/ read -ra path_paths <<<"${attrs[path]-}"
+  path_components=("" "${attrs[protocol]}://${attrs[host]}" "${path_paths[@]}")
+
+  for component in "${path_components[@]}"; do
+    url="${url:+${url}/}${component}"
+    set_username "${url}"
+  done
+}
+
+#-----------------------------------------------------------------------------
+set_username() {
+  local key="${1:+$1.}" username
+  if username=$(git config --get "credential.${key}username"); then
+    attrs[username]="${username}"
+  fi
+}
+
+#-----------------------------------------------------------------------------
+config_has_pass_path() {
+  local passPath
+  passPath=$(git config --get credential.subpath.passPath) \
+    && [[ "${passPath}" == 'true' ]]
+}
+
+#-----------------------------------------------------------------------------
+parse_args() {
+  OPTSTRING=':do:'
+  while getopts "${OPTSTRING}" opt; do
+    case "${opt}" in
+      d)
+        debug=true
+        ;;
+      o)
+        chain_args+=("${OPTARG}")
+        ;;
+      \?)
+        printf 'Invalid option: -%s\n\n' "${OPTARG}" >&2
+        usage >&2
+        exit 1
+        ;;
+      :)
+        printf 'Option -%s requires an argument\n\n' "${OPTARG}" >&2
+        usage >&2
+        exit 1
+        ;;
+    esac
+  done
+  shift $((OPTIND-1))
+
+  # Process remaining in "$@"
+  if (( $# != 2 )); then
+    usage >&2
+    exit 1
+  fi
+
+  chained_helper="$1"
+  cmd="$2"
+}
+
+#-----------------------------------------------------------------------------
+debug() {
+  "${debug}" || return 0
+  # shellcheck disable=SC2059
+  # we expect a format string as the first arg
+  printf "$@" >&2
+}
+
+debug_pipe() {
+  local logged=false
+  while read -r line; do
+    # delay logging prefix message until we read the first line from stdin
+    "${logged}" || { debug "$@"; logged=true; }
+    printf '%s\n' "${line}"
+    debug '  %s\n' "${line}"
+  done
+  debug '\n'
+}
+#-----------------------------------------------------------------------------
+[[ "$(caller)" != 0\ * ]] || main "$@"


### PR DESCRIPTION
Add a credential helper to allow usernames to be specified on a repo
subpath basis. gitcredentials(7) only work on the hostname or the full
repo path, not a subpath, such as https://github.com/org. If you want to
use different usernames for different github orgs, you can't with stock
gitcredentials.

This allows you to add a config sections such as:

    [credential]
        username = octocat1
    [credential "https://github.com/org"]
        username = octocat2

where the username `octocat1` will be used by default, but `octocat2`
will be used for any repositories under `https://github.com/org`

This helper will chain to another helper that will actually store the
passwords.