### PR TITLE
git-pr-merge: Fix shellcheck warnings

### DIFF
--- a/git-pr-merge
+++ b/git-pr-merge
@@ -39,6 +39,7 @@ main() {
 # git config --global pr.merge.sleep-time-before-delete 10
 
 prmerge::read_config() {
+  declare -g title_prefix delete_remote_branch sleep_time_before_delete
   prmerge::_migrate_config
   prmerge::_get_config title_prefix title-prefix '✨ '
   prmerge::_get_config delete_remote_branch delete-remote-branch true


### PR DESCRIPTION
Declare the variables that we read from the git config as shellcheck
cannot tell they are set as they are set dynamically with `eval.`

This gets rid of the `SC2154: var is referenced but not assigned.`
error from shellcheck.