### PR TITLE
git-pr-merge: Make script work on Mac

### DIFF
--- a/git-pr-merge
+++ b/git-pr-merge
@@ -38,8 +38,12 @@ main() {
 # git config --local pr.merge.title-prefix ''
 # git config --global pr.merge.sleep-time-before-delete 10
 
+# Pre-declare config variables so shellcheck can see it.
+title_prefix=''
+delete_remote_branch=''
+sleep_time_before_delete=''
+
 prmerge::read_config() {
-  declare -g title_prefix delete_remote_branch sleep_time_before_delete
   prmerge::_migrate_config
   prmerge::_get_config title_prefix title-prefix '✨ '
   prmerge::_get_config delete_remote_branch delete-remote-branch true


### PR DESCRIPTION
Mac's have a bloody old version of bash which do not have `declare -g`,
so just declare the variables the old fashioned way at the global scope.

Trust apple to hold back the world - they don't even know how to hold it
right - who are they to say "you're holding it wrong".