### PR TITLE
git-pr-merge: Fix level 1 headings in PR markdown

### DIFF
--- a/git-pr-merge
+++ b/git-pr-merge
@@ -191,8 +191,8 @@ markdown_for_commit_awk='
 function print_heading(line)
 {
   level1heading = match(line, /^# /) != 0
-  sub(/^##* /,"" , line)
-  marker = match(line, /^# /) != 0 ? "=" : "-"
+  sub(/^##* /, "", line)
+  marker = level1heading ? "=" : "-"
   printf("%s\n", line)
   for (i = 0; i < length(line); i++)
     printf marker


### PR DESCRIPTION
Level 1 headings were being printed with dashes and not equals signs
when converting from hash prefixes to underlines.

e.g.
 # Hello world

was being rendered as

Hello world
-----------

but it should be

Hello world
===========