### PR TITLE
git-pr-merge: merge commit from repo root

### DIFF
--- a/git-pr-merge
+++ b/git-pr-merge
@@ -88,6 +88,13 @@ prmerge::prepare() {
     return 1
   fi
 
+  # cd to root of repo as merge_to_branch may not contain CWD, but switch back
+  # when we're done.
+  # shellcheck disable=SC2064
+  # We want to evaluate $(pwd) now and not later.
+  trap "cd \"$(pwd)\"" EXIT
+  cd "$(git rev-parse --show-toplevel)"
+
   if "${switch_needed}"; then
     git checkout -q "${merge_to_branch}"
   fi

--- a/git-pr-merge
+++ b/git-pr-merge
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Merge and branch and push it to its remote, where the branch being merged
+# Merge a branch and push it to its remote, where the branch being merged
 # is for a GitHub Pull Request (PR).
 #
 # GitHub allows you to push a merge commit on a branch even when that branch
@@ -137,7 +137,10 @@ prmerge::clean() {
     else
       remote='origin'  # default if tracking not set
     fi
-    git push "${remote}" -d "${merge_from_branch}" # delete remote branch
+    if ! git push "${remote}" --delete "${merge_from_branch}"; then
+      echo 'Perhaps GitHub already deleted the branch? Disable deletion with:'
+      echo 'git config pr.merge.delete-remote-branch false'
+    fi
   fi
 }
 


### PR DESCRIPTION
Change directory to the repo root before merging the branch. This is 
necessary as the current directory may not exist on master when the 
currently-being-merged branch has added it. When we switch back to master
to merge the branch, we end up in a "detached" directory. How this is
handled can depend on whether it is a local or network filesystem, or
depending on the OS.

By changing to the repo root directory, we avoid any of this uncertainty.
We change back once the merge is complete, as that directory will exist
then.

Add a branch deletion help message and make a minor fix to the script comment
header.