### PR TITLE
Fix unbound variable error on old bash

### DIFF
--- a/git-pr-merge
+++ b/git-pr-merge
@@ -105,7 +105,7 @@ prmerge() {
   args=()
   common::read_config
   prmerge::parse_args "$@"
-  common::setup "${args[@]}"
+  common::setup ${args[@]+"${args[@]}"}
   prmerge::prepare
   prmerge::merge
   prmerge::push


### PR DESCRIPTION
Fix unbound variable error on old bash as we usually have it on macs.
Original error message:

	line 108: args[@]: unbound variable