### PR TITLE
git-pr-merge: Squash merge using API, not `gh pr merge`

### DIFF
--- a/git-pr-merge
+++ b/git-pr-merge
@@ -324,8 +324,20 @@ prmerge::squash_merge() {
     git checkout -q "${feature}"
     return 1
   fi
+  local commit_title commit_message
+  commit_title=$(grep -v '^[[:space:]]*#' "${commit_msg_file}" | head -n 1)
+  commit_message=$(grep -v '^[[:space:]]*#' "${commit_msg_file}" | tail -n +3)
 
-  if ! gh pr merge "${pr_num}" --squash --body-file "${commit_msg_file}"; then
+  local result
+  if ! result=$(gh api "repos/{owner}/{repo}/pulls/${pr_num}/merge" \
+    --method PUT \
+    --header 'Accept: application/vnd.github.v3+json' \
+    --raw-field "commit_title=${commit_title}" \
+    --raw-field "commit_message=${commit_message}"$'\n' \
+    --raw-field "sha=$(git rev-parse "${feature}")" \
+    --raw-field "merge_method=squash"
+  ); then
+    jq -r .message <<<"${result}"
     git checkout -q "${feature}"
     return 1
   fi


### PR DESCRIPTION
Use `gh api` to perform a squash merge instead of using `gh pr merge`.
The latter does not allow you to set the title of the squash merge
commit - it uses the PR title, but we want to add a title prefix.
Currently it "doubles up" the title.

This partially reverts 759e1b54402519aa190f68ef689a5af4132901e0 but
converts `hub api` to `gh api`, putting flags last and removing the
leading slash of the API, as this is what `gh api --help` says.