### PR TITLE
git-pr-merge: Strip reviewer comments from PR message

### DIFF
--- a/git-pr-merge
+++ b/git-pr-merge
@@ -542,4 +542,5 @@ function print_heading(line)
   printf("%s%s\n", in_code_block ? "    " : "", $0)
 }'
 
-[[ "$(caller)" != 0\ * ]] || main "$@" # Run main if file not sourced
+# Only run main if executed as a script and not sourced.
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then main "$@"; fi

--- a/git-pr-merge
+++ b/git-pr-merge
@@ -503,7 +503,7 @@ common::pr_message() {
 }
 
 # shellcheck disable=SC2016
-# We don't want to expand to expand expressions, so single quotes.
+# We don't want to expand shell expressions (it's awk!), so single quotes.
 markdown_for_commit_awk='
 # print_heading converts a heading starting with a hash to one with an
 # underline, as a line starting with a hash in a git commit message is
@@ -518,6 +518,11 @@ function print_heading(line)
     printf marker
   printf "\n"
 }
+
+# If there is a triple dash line --- preceded by a blank line, throw
+# it out and everything after it. These are reviewer notes and do not
+# go into the commit message.
+/^---$/ && last_blank { exit }
 
 # If we want a blank and the current line is not blank, inject a blank line.
 /\S/ && want_blank { print "" }


### PR DESCRIPTION
When constructing a merge commit message from a pull request body
(description), remove anything after a blank line followed by a line solely
of `---`. including the marker line. The `---` indicates the start of
reviewer comments of a PR and should not be included in the merge commit
message. This is the same as `git-am` does in a way - the commit message
comes before the `---` and the patch after. Patching ignores any text
before the formal start of the patch.